### PR TITLE
Support for the Rust's custom allocator API on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["bit", "vector", "bitvec"]
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["std"]
-std = []
+default = []
 unstable = []
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bitvec-rs"
 version = "0.2.0"
+edition = "2021"
 authors = ["Ashish Myles <marcianx@gmail.com>"]
 repository = "https://github.com/marcianx/bitvec-rs"
 description = """
@@ -10,6 +11,10 @@ immutable and mutable views into its internal vector for easy I/O.
 readme = "README.md"
 keywords = ["bit", "vector", "bitvec"]
 license = "MIT/Apache-2.0"
+
+[features]
+default = []
+custom-allocator = []
 
 [dependencies.serde]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 [features]
 default = ["std"]
 std = []
-custom-allocator = []
+unstable = []
 
 [dependencies.serde]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitvec-rs"
 version = "0.2.0"
 edition = "2021"
-authors = ["Ashish Myles <marcianx@gmail.com>"]
+authors = ["Ashish Myles <marcianx@gmail.com>", "TeleportAura"]
 repository = "https://github.com/marcianx/bitvec-rs"
 description = """
 Bit vector with guaranteed `[u8]` representation and the ability to get safe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ keywords = ["bit", "vector", "bitvec"]
 license = "MIT/Apache-2.0"
 
 [features]
-default = []
+default = ["std"]
+std = []
 custom-allocator = []
 
 [dependencies.serde]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Ashish Myles
+Copyright (c) 2015 Ashish Myles and contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ It mirrors the API of `std::vec::Vec` as much as possible. Notable differences:
 
 ## License
 
-Copyright 2019, Ashish Myles.
+Copyright 2019, Ashish Myles (maintainer) and contributors.
 This software is dual-licensed under the [MIT](LICENSE-MIT) and
 [Apache 2.0](LICENSE-APACHE) licenses.

--- a/README.tpl
+++ b/README.tpl
@@ -2,7 +2,7 @@
 
 ## License
 
-Copyright 2019, Ashish Myles.
+Copyright 2019, Ashish Myles (maintainer) and contributors.
 This software is dual-licensed under the [MIT](LICENSE-MIT) and
 [Apache 2.0](LICENSE-APACHE) licenses.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,7 +691,7 @@ mod test {
     #[test]
     #[should_panic(expected = "out of bounds")]
     fn test_set_validation() {
-        &BitVec::from_bytes(&[0xef, 0xa5, 0x71]).set(24, true);
+        let _ = &BitVec::from_bytes(&[0xef, 0xa5, 0x71]).set(24, true);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,7 @@ impl<A: Allocator> core::ops::Index<usize> for BitVec<A> {
 #[cfg(test)]
 mod test {
     use super::BitVec;
+    use alloc::{vec::Vec, vec, format};
 
     #[test]
     fn test_index() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,6 @@ use core::prelude::rust_2021::*;
 use alloc::vec::Vec;
 use alloc::vec;
 #[cfg(feature = "unstable")]
-#[cfg(feature = "std")]
-use std::alloc::Global;
-#[cfg(feature = "unstable")]
-#[cfg(not(feature = "std"))]
 use alloc::alloc::Global;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use core::write;
 use core::prelude::rust_2021::*;
 use alloc::vec::Vec;
 use alloc::vec;
-use core::default::Default;
 #[cfg(feature = "unstable")]
 #[cfg(feature = "std")]
 use std::alloc::Global;
@@ -47,8 +46,8 @@ pub struct BitVec {
 /// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Clone, Default)]
-pub struct BitVec<A: Allocator = Global> where Vec<u8, A>: Default {
+#[derive(Clone)]
+pub struct BitVec<A: Allocator = Global> {
     nbits: usize,
     vec: Vec<u8, A>,
 }
@@ -57,9 +56,7 @@ pub struct BitVec<A: Allocator = Global> where Vec<u8, A>: Default {
 // they use the same allocator or whether their allocator implements
 // PartialEq or not
 #[cfg(feature = "unstable")]
-impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A>
-    where Vec<u8, B>: Default, Vec<u8, A>: Default
-{
+impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A> {
     
     fn eq(&self, other: &BitVec<B>) -> bool {
         self.nbits == other.nbits && self.vec == other.vec
@@ -71,8 +68,17 @@ impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A>
 
 }
 
+#[cfg(feauture = "unstable")]
+impl Default for BitVec {
+    
+    fn default() -> Self {
+        Self { nbits: 0, vec: Vec::new() }
+    }
+
+}
+
 #[cfg(feature = "unstable")]
-impl<A: Allocator> Eq for BitVec<A> where Vec<u8, A>: Default {}
+impl<A: Allocator> Eq for BitVec<A> {}
 
 fn bytes_in_bits(nbits: usize) -> usize {
     // #bytes = #ceil(nbits / 8)
@@ -83,12 +89,21 @@ fn byte_from_bool(bit: bool) -> u8 {
     if bit { !0u8 } else { 0u8 }
 }
 
+#[cfg(feature = "unstable")]
+impl<A: Allocator> BitVec<A> {
+
+    pub const fn new_in(alloc: A) -> Self {
+        Self { vec: Vec::new_in(alloc), nbits: 0}
+    }
+
+}
+
 impl BitVec {
     ////////////////////////////////////////
     // Constructors
 
     /// Constructs an empty `BitVec`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { vec: Vec::new(), nbits: 0 }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "custom-allocator", feature(allocator_api))]
+
 //! This is a bit vector implementation with guaranteed `[u8]` [LSB 0][1]
 //! representation and the ability to get safe immutable and mutable views into its
 //! internal vector for easy I/O.
@@ -9,19 +11,34 @@
 
 // TODO: Flesh out docs.
 
+#[cfg(feature = "custom-allocator")]
+use core::alloc::Allocator;
 use std::fmt;
 use std::num::Wrapping;
+#[cfg(feature = "custom-allocator")]
+use std::alloc::Global;
 
 #[cfg(feature = "serde")]
 #[macro_use] extern crate serde;
 
 /// Bit vector with guaranteed `[u8]` LSB 0 representation and safe mutable access to this slice.
 /// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
+#[cfg(not(feature = "custom-allocator"))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct BitVec {
     nbits: usize,
     vec: Vec<u8>
+}
+
+/// Bit vector with guaranteed `[u8]` LSB 0 representation and safe mutable access to this slice.
+/// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
+#[cfg(feature = "custom-allocator")]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct BitVec<A: Allocator = Global> where Vec<u8, A>: Default {
+    nbits: usize,
+    vec: Vec<u8, A>
 }
 
 fn bytes_in_bits(nbits: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,16 +50,12 @@ pub struct BitVec<A: Allocator = Global> {
 
 // Explicitly allow comparisons between BitVecs regardless of whether
 // they use the same allocator or whether their allocator implements
-// PartialEq or not
+// PartialEq or not.
 #[cfg(feature = "unstable")]
 impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A> {
     
     fn eq(&self, other: &BitVec<B>) -> bool {
         self.nbits == other.nbits && self.vec == other.vec
-    }
-
-    fn ne(&self, other: &BitVec<B>) -> bool {
-        self.nbits != other.nbits || self.vec != other.vec
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "custom-allocator", feature(allocator_api))]
+#![cfg_attr(feature = "unstable", feature(allocator_api))]
 
 //! This is a bit vector implementation with guaranteed `[u8]` [LSB 0][1]
 //! representation and the ability to get safe immutable and mutable views into its
@@ -14,7 +14,7 @@
 
 extern crate alloc;
 
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 use core::alloc::Allocator;
 use core::fmt;
 use core::num::Wrapping;
@@ -23,10 +23,10 @@ use core::prelude::rust_2021::*;
 use alloc::vec::Vec;
 use alloc::vec;
 use core::default::Default;
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 #[cfg(feature = "std")]
 use std::alloc::Global;
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 #[cfg(not(feature = "std"))]
 use alloc::alloc::Global;
 
@@ -35,7 +35,7 @@ use alloc::alloc::Global;
 
 /// Bit vector with guaranteed `[u8]` LSB 0 representation and safe mutable access to this slice.
 /// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
-#[cfg(not(feature = "custom-allocator"))]
+#[cfg(not(feature = "unstable"))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct BitVec {
@@ -45,18 +45,18 @@ pub struct BitVec {
 
 /// Bit vector with guaranteed `[u8]` LSB 0 representation and safe mutable access to this slice.
 /// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Default)]
 pub struct BitVec<A: Allocator = Global> where Vec<u8, A>: Default {
     nbits: usize,
-    vec: Vec<u8, A>
+    vec: Vec<u8, A>,
 }
 
-// explicitly allow comparisons between BitVecs regardless of whether
+// Explicitly allow comparisons between BitVecs regardless of whether
 // they use the same allocator or whether their allocator implements
 // PartialEq or not
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A>
     where Vec<u8, B>: Default, Vec<u8, A>: Default
 {
@@ -71,7 +71,7 @@ impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A>
 
 }
 
-#[cfg(feature = "custom-allocator")]
+#[cfg(feature = "unstable")]
 impl<A: Allocator> Eq for BitVec<A> where Vec<u8, A>: Default {}
 
 fn bytes_in_bits(nbits: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,32 @@ pub struct BitVec {
 /// Slices into the bit vector are guaranteed to have the unused bits on the last byte set to 0.
 #[cfg(feature = "custom-allocator")]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default)]
 pub struct BitVec<A: Allocator = Global> where Vec<u8, A>: Default {
     nbits: usize,
     vec: Vec<u8, A>
 }
+
+// explicitly allow comparisons between BitVecs regardless of whether
+// they use the same allocator or whether their allocator implements
+// PartialEq or not
+#[cfg(feature = "custom-allocator")]
+impl<A: Allocator, B: Allocator> PartialEq<BitVec<B>> for BitVec<A>
+    where Vec<u8, B>: Default, Vec<u8, A>: Default
+{
+    
+    fn eq(&self, other: &BitVec<B>) -> bool {
+        self.nbits == other.nbits && self.vec == other.vec
+    }
+
+    fn ne(&self, other: &BitVec<B>) -> bool {
+        self.nbits != other.nbits || self.vec != other.vec
+    }
+
+}
+
+#[cfg(feature = "custom-allocator")]
+impl Eq for BitVec {}
 
 fn bytes_in_bits(nbits: usize) -> usize {
     // #bytes = #ceil(nbits / 8)


### PR DESCRIPTION
This makes it possible to use this crate with a [custom allocator](https://github.com/rust-lang/rust/issues/32838) on Rust nightly.
Imo, this should be merged because it would make this crate the first bitvec crate to be able to be used in bare metal projects

Due to the fact that custom allocators currently only work on nightly, there is some code duplication which I could probably remove using macros if this is an issue. 
The explicit implementation of PartialEq is required because the derive macro doesn't work unless the traitbound for the allocator also requires it to implement PartialEq which is a pretty stupid requirement.
Other than that, I tried to adhere to the code style in the original

I also updated the edition to be 2021 and fixed one compiler warning in a separate commit